### PR TITLE
muxadd breaks Quicklogic dsp inference, make it optional

### DIFF
--- a/passes/pmgen/peepopt.cc
+++ b/passes/pmgen/peepopt.cc
@@ -45,8 +45,6 @@ struct PeepoptPass : public Pass {
 		log("\n");
 		log("This pass employs the following rules by default:\n");
 		log("\n");
-		log("   * muxadd - Replace S?(A+B):A with A+(S?B:0)\n");
-		log("\n");
 		log("   * muldiv - Replace (A*B)/B with A\n");
 		log("\n");
 		log("   * muldiv_c - Replace (A*B)/C with A*(B/C) when C is a const divisible by B.\n");
@@ -70,18 +68,26 @@ struct PeepoptPass : public Pass {
 		log("                   based pattern to prevent combinational paths from the\n");
 		log("                   output to the enable input after running clk2fflogic.\n");
 		log("\n");
+		log("If -withmuxadd is specified it adds the following rule:\n");
+		log("\n");
+		log("   * muxadd - Replace S?(A+B):A with A+(S?B:0)\n");
+		log("\n");
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
 		log_header(design, "Executing PEEPOPT pass (run peephole optimizers).\n");
 
 		bool formalclk = false;
-
+		bool withmuxadd = false;
 		size_t argidx;
 		for (argidx = 1; argidx < args.size(); argidx++)
 		{
 			if (args[argidx] == "-formalclk") {
 				formalclk = true;
+				continue;
+			}
+			if (args[argidx] == "-withmuxadd") {
+				withmuxadd = true;
 				continue;
 			}
 			break;
@@ -113,7 +119,8 @@ struct PeepoptPass : public Pass {
 					pm.run_shiftmul_left();
 					pm.run_muldiv();
 					pm.run_muldiv_c();
-					pm.run_muxadd();
+					if (withmuxadd)
+						pm.run_muxadd();
 				}
 			}
 		}

--- a/tests/peepopt/muxadd.ys
+++ b/tests/peepopt/muxadd.ys
@@ -1,3 +1,8 @@
+
+
+log -header "Test basic s?(a+b):a pattern gets transformed (a,b module inputs)"
+log -push
+design -reset
 log -header "Test basic s?(a+b):a pattern gets transformed (a,b module inputs)"
 log -push
 design -reset
@@ -13,7 +18,7 @@ module top(a, b, s, y);
 endmodule
 EOF
 check -assert
-equiv_opt -assert peepopt
+equiv_opt -assert peepopt -withmuxadd
 design -load postopt
 select -assert-any t:$add %co1 %a w:y %i # assert adder rewired
 log -pop
@@ -31,7 +36,7 @@ module top(a, b, s, y);
 endmodule
 EOF
 check -assert
-equiv_opt -assert peepopt
+equiv_opt -assert peepopt -withmuxadd
 design -load postopt
 select -assert-any t:$add %co1 %a w:y %i # assert adder rewired
 log -pop
@@ -51,7 +56,7 @@ module top(a, b, s, y);
 endmodule
 EOF
 check -assert
-equiv_opt -assert peepopt
+equiv_opt -assert peepopt -withmuxadd
 design -load postopt
 select -assert-any t:$add %co1 %a w:y %i # assert adder rewired
 log -pop
@@ -72,7 +77,7 @@ module top(a_, b, s, y);
 endmodule
 EOF
 check -assert
-equiv_opt -assert peepopt
+equiv_opt -assert peepopt -withmuxadd
 design -load postopt
 select -assert-any t:$add %co1 %a w:y %i # assert adder rewired
 log -pop
@@ -96,7 +101,7 @@ module top(a, b_, f, s, y_);
 endmodule
 EOF
 check -assert
-equiv_opt -assert peepopt
+equiv_opt -assert peepopt -withmuxadd
 design -load postopt
 select -assert-any t:$add %co1 %a w:y %i # assert adder rewired
 log -pop
@@ -116,7 +121,7 @@ module top(a, b, ab, s, y);
 endmodule
 EOF
 check -assert
-equiv_opt -assert peepopt
+equiv_opt -assert peepopt -withmuxadd
 design -load postopt
 select -assert-none t:$add %co1 %a w:y %i
 log -pop
@@ -136,7 +141,7 @@ module top(a, b, s, y, z);
 endmodule
 EOF
 check -assert
-equiv_opt -assert peepopt
+equiv_opt -assert peepopt -withmuxadd
 design -load postopt
 select -assert-none t:$add %co1 %a w:y %i
 
@@ -157,7 +162,7 @@ EOF
 check -assert
 wreduce
 opt_clean
-equiv_opt -assert peepopt
+equiv_opt -assert peepopt -withmuxadd
 design -load postopt
 select -assert-none t:$add %co1 %a w:y %i
 
@@ -178,7 +183,7 @@ EOF
 check -assert
 wreduce
 opt_clean
-equiv_opt -assert peepopt
+equiv_opt -assert peepopt -withmuxadd
 design -load postopt
 select -assert-none t:$add %co1 %a w:y %i
 
@@ -199,7 +204,7 @@ EOF
 check -assert
 wreduce
 opt_clean
-equiv_opt -assert peepopt
+equiv_opt -assert peepopt -withmuxadd
 design -load postopt
 select -assert-none t:$add %co1 %a w:y %i
 
@@ -221,7 +226,7 @@ EOF
 check -assert
 wreduce
 opt_clean
-equiv_opt -assert peepopt
+equiv_opt -assert peepopt -withmuxadd
 design -load postopt
 select -assert-none t:$add %co1 %a w:y %i
 
@@ -242,7 +247,7 @@ EOF
 check -assert
 wreduce
 opt_clean
-equiv_opt -assert peepopt
+equiv_opt -assert peepopt -withmuxadd
 design -load postopt
 select -assert-any t:$add %co1 %a w:y %i
 
@@ -263,7 +268,7 @@ EOF
 check -assert
 wreduce
 opt_clean
-equiv_opt -assert peepopt
+equiv_opt -assert peepopt -withmuxadd
 design -load postopt
 select -assert-any t:$add %co1 %a w:y %i
 
@@ -284,7 +289,7 @@ EOF
 check -assert
 wreduce
 opt_clean
-equiv_opt -assert peepopt
+equiv_opt -assert peepopt -withmuxadd
 design -load postopt
 select -assert-any t:$add %co1 %a w:y %i # assert adder rewired
 
@@ -305,7 +310,7 @@ EOF
 check -assert
 wreduce
 opt_clean
-equiv_opt -assert peepopt
+equiv_opt -assert peepopt -withmuxadd
 design -load postopt
 select -assert-any t:$add %co1 %a w:y %i # assert adder rewired
 
@@ -326,7 +331,7 @@ EOF
 check -assert
 wreduce
 opt_clean
-equiv_opt -assert peepopt
+equiv_opt -assert peepopt -withmuxadd
 design -load postopt
 select -assert-any t:$add %co1 %a w:y %i # assert adder rewired
 
@@ -347,7 +352,7 @@ EOF
 check -assert
 wreduce
 opt_clean
-equiv_opt -assert peepopt
+equiv_opt -assert peepopt -withmuxadd
 design -load postopt
 select -assert-any t:$add %co1 %a w:y %i # assert adder rewired
 
@@ -368,6 +373,6 @@ EOF
 check -assert
 wreduce
 opt_clean
-equiv_opt -assert peepopt
+equiv_opt -assert peepopt -withmuxadd
 design -load postopt
 select -assert-any t:$add %co1 %a w:y %i # assert adder rewired


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

For test tests/arch/quicklogic/qlf_k6n10f/dsp.ys
This pass prevents Quicklogic inference to map to a QL_DSP2_MULTACC.
Once transformed by this peepopt, the particular inference pattern probably does not match anymore the structure.

_Explain how this is achieved._

Make this transform optional.

_If applicable, please suggest to reviewers how they can test the change._
